### PR TITLE
Disable Build-Time Checks

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+import type {NextConfig} from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Disable ESLint during production builds
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+
+  // Disable TypeScript type checking during builds
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# Disable Build-Time Checks

## Summary
Temporarily disables ESLint and TypeScript error checking during builds for faster development.

## What's Changed
- Modified `next.config.ts` to ignore build errors
- Added `eslint.ignoreDuringBuilds: true`
- Added `typescript.ignoreBuildErrors: true`

## Configuration
```typescript
const nextConfig: NextConfig = {
  eslint: {
    ignoreDuringBuilds: true,
  },
  typescript: {
    ignoreBuildErrors: true,
  },
};